### PR TITLE
 Changes for ubuntu 22.04: take 2

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,8 +1,5 @@
 project(qtbind)
 
-# Always force c++03 standard
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
-
 add_subdirectory(generator)
 
 # where to look first for cmake modules, before ${CMAKE_ROOT}/Modules/ is checked

--- a/ext/generator/parser/parsesession.cpp
+++ b/ext/generator/parser/parsesession.cpp
@@ -59,7 +59,7 @@ QPair<rpp::Anchor, uint> ParseSession::positionAndSpaceAt(std::size_t offset, bo
 
 std::size_t ParseSession::size() const
 {
-  return m_contents.size() + 1;
+  return m_contents.size();
 }
 
  uint* ParseSession::contents()

--- a/ext/smoke/CMakeLists.txt
+++ b/ext/smoke/CMakeLists.txt
@@ -1,5 +1,11 @@
 project(SMOKE)
 
+# Always force c++03 standard
+# This is required because smoke derives from
+# classes and some have a private destructor that
+# makes them final starting with c++11.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
+
 add_definitions(-DSMOKE_BUILDING)
 
 add_subdirectory(smokebase)


### PR DESCRIPTION
This is a pair of patches that enables this gem to compile and work on ubuntu 22.04. All three c++ side test suites pass, and gui/vizkits rock-display starts and displays.

@doudou want to roll a new release with this? The changes seem safe enough to me.